### PR TITLE
Added support for `functionality_storage` & `security_storage`

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -131,6 +131,50 @@ ___TEMPLATE_PARAMETERS___
           },
           {
             "param": {
+              "type": "SELECT",
+              "name": "functionality_storage",
+              "displayName": "Functionality",
+              "macrosInSelect": true,
+              "selectItems": [
+                {
+                  "value": "granted",
+                  "displayValue": "granted"
+                },
+                {
+                  "value": "denied",
+                  "displayValue": "denied"
+                }
+              ],
+              "simpleValueType": true,
+              "defaultValue": "granted",
+              "help": ""
+            },
+            "isUnique": false
+          },
+          {
+            "param": {
+              "type": "SELECT",
+              "name": "security_storage",
+              "displayName": "Security",
+              "macrosInSelect": true,
+              "selectItems": [
+                {
+                  "value": "granted",
+                  "displayValue": "granted"
+                },
+                {
+                  "value": "denied",
+                  "displayValue": "denied"
+                }
+              ],
+              "simpleValueType": true,
+              "defaultValue": "granted",
+              "help": ""
+            },
+            "isUnique": false
+          },
+          {
+            "param": {
               "type": "TEXT",
               "name": "wait_for_update",
               "displayName": "Wait for Update",
@@ -236,6 +280,42 @@ ___TEMPLATE_PARAMETERS___
         ],
         "simpleValueType": true,
         "defaultValue": "granted"
+      },
+      {
+        "type": "SELECT",
+        "name": "update_functionality_storage",
+        "displayName": "Functionality",
+        "macrosInSelect": true,
+        "selectItems": [
+          {
+            "value": "granted",
+            "displayValue": "granted"
+          },
+          {
+            "value": "denied",
+            "displayValue": "denied"
+          }
+        ],
+        "simpleValueType": true,
+        "defaultValue": "granted"
+      },
+      {
+        "type": "SELECT",
+        "name": "update_security_storage",
+        "displayName": "Security",
+        "macrosInSelect": true,
+        "selectItems": [
+          {
+            "value": "granted",
+            "displayValue": "granted"
+          },
+          {
+            "value": "denied",
+            "displayValue": "denied"
+          }
+        ],
+        "simpleValueType": true,
+        "defaultValue": "granted"
       }
     ],
     "enablingConditions": [
@@ -300,12 +380,14 @@ if (data.url_passthrough) gtag('set', 'url_passthrough', true);
 if (data.ads_data_redaction) gtag('set', 'ads_data_redaction', true);
 
 // dataLayer.push helper
-const dlPush = (isDefault, ads, analytics, personalization, region) => {
+const dlPush = (isDefault, ads, analytics, personalization, functionality, security, region) => {
   dataLayerPush({
     event: 'gtm_consent_' + (isDefault ? 'default' : 'update'),
     ad_storage: ads,
     analytics_storage: analytics,
     personalization_storage: personalization,
+    functionality_storage: functionality,
+    security_storage: security,
     consent_region: region
   });
 };
@@ -317,6 +399,8 @@ if (data.command === 'default') {
       ad_storage: setting.ad_storage,
       analytics_storage: setting.analytics_storage,
       personalization_storage: setting.personalization_storage,
+      functionality_storage: setting.functionality_storage,
+      security_storage: setting.security_storage,
       wait_for_update: setting.wait_for_update
     };
     if (setting.regions !== 'all') {
@@ -325,7 +409,7 @@ if (data.command === 'default') {
     setDefaultConsentState(settingObject);
     if (data.sendGtag) gtag('consent', 'default', settingObject);
     if (data.sendDataLayer) {
-      dlPush(true, setting.ad_storage, setting.analytics_storage, setting.personalization_storage, settingObject.region);
+      dlPush(true, setting.ad_storage, setting.analytics_storage, setting.personalization_storage, setting.functionality_storage, setting.security_storage, settingObject.region);
     }
   });
 }
@@ -336,16 +420,20 @@ if (data.command === 'update') {
     gtag('consent', 'update', {
       ad_storage: data.update_ad_storage,
       analytics_storage: data.update_analytics_storage,
-      personalization_storage: data.update_personalization_storage
+      personalization_storage: data.update_personalization_storage,
+      functionality_storage: data.update_functionality_storage,
+      security_storage: data.update_security_storage
     });
   }
   updateConsentState({
     ad_storage: data.update_ad_storage,
     analytics_storage: data.update_analytics_storage,
-    personalization_storage: data.update_personalization_storage
+    personalization_storage: data.update_personalization_storage,
+    functionality_storage: data.update_functionality_storage,
+    security_storage: data.update_security_storage
   });
   if (data.sendDataLayer) {
-    dlPush(false, data.update_ad_storage, data.update_analytics_storage, data.update_personalization_storage);
+    dlPush(false, data.update_ad_storage, data.update_analytics_storage, data.update_personalization_storage, data.update_functionality_storage, data.update_security_storage);
   }
 }
 
@@ -653,6 +741,8 @@ scenarios:
             ad_storage: 'granted',
             analytics_storage: 'denied',
             personalization_storage: 'denied',
+            functionality_storage: 'denied',
+            security_storage: 'denied',
             wait_for_update: 500
           });
           index++;
@@ -661,6 +751,8 @@ scenarios:
             ad_storage: 'denied',
             analytics_storage: 'granted',
             personalization_storage: 'granted',
+            functionality_storage: 'granted',
+            security_storage: 'granted',
             wait_for_update: 1000,
             region: ['ES', 'US-AK']
           });
@@ -675,12 +767,16 @@ scenarios:
       ad_storage: 'granted',
       analytics_storage: 'denied',
       personalization_storage: 'denied',
+      functionality_storage: 'denied',
+      security_storage: 'denied',
       wait_for_update: 500
     });
     assertApi('setDefaultConsentState').wasCalledWith({
       ad_storage: 'denied',
       analytics_storage: 'granted',
       personalization_storage: 'granted',
+      functionality_storage: 'granted',
+      security_storage: 'granted',
       region: ['ES', 'US-AK'],
       wait_for_update: 1000
     });
@@ -695,7 +791,9 @@ scenarios:
           assertThat(arguments[2]).isEqualTo({
             ad_storage: 'denied',
             analytics_storage: 'granted',
-            personalization_storage: 'granted'
+            personalization_storage: 'granted',
+            functionality_storage: 'granted',
+            security_storage: 'granted'
           });
         }
       };
@@ -707,7 +805,9 @@ scenarios:
     assertApi('updateConsentState').wasCalledWith({
       ad_storage: 'denied',
       analytics_storage: 'granted',
-      personalization_storage: 'granted'
+      personalization_storage: 'granted',
+      functionality_storage: 'granted',
+      security_storage: 'granted'
     });
     assertApi('gtmOnSuccess').wasCalled();
 - name: extra settings sent
@@ -724,16 +824,23 @@ scenarios:
     // Verify that the tag finished successfully.
     assertApi('gtmOnSuccess').wasCalled();
 - name: dataLayer events generated
-  code: "mockData.sendDataLayer = true;\n\nlet dlCalled = 0;\n\nmock('createQueue',\
-    \ name => {\n  return o => {\n    require('logToConsole')(o);\n    if (o.event\
-    \ === 'gtm_consent_default' && o.ad_storage === 'granted' && o.analytics_storage\
-    \ === 'denied' && o.personalization_storage === 'denied') dlCalled++;\n    if\
-    \ (o.event === 'gtm_consent_default' && o.ad_storage === 'denied' && o.analytics_storage\
-    \ === 'granted' && o.personalization_storage === 'granted' && o.consent_region.join()\
-    \ === 'ES,US-AK') dlCalled++;\n  };\n});\n    \n// Call runCode to run the template's\
-    \ code.\nrunCode(mockData);\n\n// Verify that the tag finished successfully.\n\
-    assertApi('gtmOnSuccess').wasCalled();\nassertThat(dlCalled, 'dataLayer not called\
-    \ with correct arguments').isEqualTo(2);"
+  code: |-
+    mockData.sendDataLayer = true;
+    let dlCalled = 0;
+    mock('createQueue', name => {
+      return o => {
+        require('logToConsole')(o);
+        if (o.event === 'gtm_consent_default' && o.ad_storage === 'granted' && o.analytics_storage === 'denied' && o.personalization_storage === 'denied' && o.functionality_storage === 'denied' && o.security_storage === 'denied') dlCalled++;
+        if (o.event === 'gtm_consent_default' && o.ad_storage === 'denied' && o.analytics_storage === 'granted' && o.personalization_storage === 'granted' && o.functionality_storage === 'granted' && o.security_storage === 'granted' && o.consent_region.join() === 'ES,US-AK') dlCalled++;
+      };
+    });
+
+    // Call runCode to run the template's code.
+    runCode(mockData);
+
+    // Verify that the tag finished successfully.
+    assertApi('gtmOnSuccess').wasCalled();
+    assertThat(dlCalled, 'dataLayer not called with correct arguments').isEqualTo(2);
 setup: |-
   const mockData = {
     command: 'default',
@@ -741,18 +848,24 @@ setup: |-
       ad_storage: 'granted',
       analytics_storage: 'denied',
       personalization_storage: 'denied',
+      functionality_storage: 'denied',
+      security_storage: 'denied',
       wait_for_update: 500,
       regions: 'all'
     },{
       ad_storage: 'denied',
       analytics_storage: 'granted',
       personalization_storage: 'granted',
+      functionality_storage: 'granted',
+      security_storage: 'granted',
       wait_for_update: 1000,
       regions: 'ES, US-AK'
     }],
     update_analytics_storage: 'granted',
     update_ad_storage: 'denied',
     update_personalization_storage: 'granted',
+    update_functionality_storage: 'granted',
+    update_security_storage: 'granted',
     url_passthrough: true,
     ads_data_redaction: true,
     sendDataLayer: false,
@@ -763,5 +876,6 @@ setup: |-
 ___NOTES___
 
 Created on 07/10/2020, 10:39:35
+Updated with `functionality_storage` & `security_storage` support by Sven Parker @ Trustcruit 08/02/2022
 
 


### PR DESCRIPTION
Hey, just after finishing up the addition of support for `functionality_storage` & `security_storage`. I saw in the other PR #1 that you can consider these categories as "strictly necessary"...

Sooo to not let my last hour have been to waste. I'll just go ahead and share this here if this helps anybody. Mostly with the information of them being considered "strictly necessary".

You don’t need to pull in this PR if you don’t reaaally want to. Thanks for the great work and great info on your website. Finally up and running with a nice cookie consent! This has been an utter mess really.